### PR TITLE
Fix microservice generator for .NET

### DIFF
--- a/kubersaur-maven-plugin/pom.xml
+++ b/kubersaur-maven-plugin/pom.xml
@@ -17,11 +17,6 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
       <version>3.6.3</version>
     </dependency>
     <dependency>

--- a/kubersaur/src/main/java/com/darthShana/kubersaur/generator/microservice/service/csharp/MicroserviceImplGenerator.java
+++ b/kubersaur/src/main/java/com/darthShana/kubersaur/generator/microservice/service/csharp/MicroserviceImplGenerator.java
@@ -9,16 +9,14 @@ import java.io.File;
 import java.io.IOException;
 
 public class MicroserviceImplGenerator extends Generator implements org.kubersaur.codegen.implementation.CodegenConfig{
-    private String name;
     private String baseDirectory;
     private String templateDirectory;
-    private Org org;
 
     public MicroserviceImplGenerator(){}
 
     @Override
     public void init(String name, String implementationBaseDirectory, String templateDir, Org org) {
-        this.name = name;
+        this.microserviceName = name;
         this.baseDirectory = implementationBaseDirectory;
         this.templateDirectory = templateDir+"csharp/";
         this.org = org;
@@ -41,7 +39,7 @@ public class MicroserviceImplGenerator extends Generator implements org.kubersau
         new File(baseDirectory+"target/").mkdirs();
 
 
-        new FileGeneratorBuilder(name+"-service.csproj")
+        new FileGeneratorBuilder(microserviceName+"-service.csproj")
                 .atLocation(baseDirectory)
                 .withTemplate(templateDirectory+"serviceCSProj.mustache")
                 .generate(this);

--- a/kubersaur/src/main/resources/code/service/csharp/dockerignore.mustache
+++ b/kubersaur/src/main/resources/code/service/csharp/dockerignore.mustache
@@ -1,2 +1,7 @@
-bin\
-obj\
+**/bin
+**/obj
+**/out
+**/.vscode
+**/.vs
+.dotnet
+.Microsoft.DotNet.ImageBuilder


### PR DESCRIPTION
- Use `this.microserviceName` and `this.org` in the same way as Java's generator
- Use `microserviceName` for the csproj mustache as we no longer have a `name`.
- Use `.dockerignore` file from Microsoft's examples https://github.com/dotnet/dotnet-docker/blob/main/.dockerignore as the previous one was broken.
- Fix duplicate dependency versions in pom by removing the older dependency